### PR TITLE
expose the Checkout target, that does not depend on PhoneNumberKit

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,10 @@ let package = Package(
         .library(
             name: "Frames",
             targets: ["Frames"]
+        ),
+        .library(
+            name: "Checkout",
+            targets: ["Checkout"]
         )
     ],
     dependencies: [


### PR DESCRIPTION
This is to sort out the dependency conflict we have between the Sling app and Frames, on the PhoneNumberKit dependency version

https://avianlabsworkspace.slack.com/archives/C06G849125N/p1731069957434799